### PR TITLE
Remove array from main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,6 @@
   "homepage": "https://github.com/mikejacobson/angular-bootstrap-scrolling-tabs",
   "bugs": "https://github.com/mikejacobson/angular-bootstrap-scrolling-tabs/issues",
   "author": "Mike Jacobson <michaeljjacobson1@gmail.com>",
-  "main": [
-    "scrolling-tabs.js",
-    "scrolling-tabs.css"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/mikejacobson/angular-bootstrap-scrolling-tabs.git"


### PR DESCRIPTION
Looks like the package.json was copied over from bower.json-- main shouldn't be an array in package.json: https://docs.npmjs.com/files/package.json#main

This can cause issues in automated build systems that examine package.json (even if they're following bower.json conventions)
